### PR TITLE
refactor: rename selectors to follow BEM syntax

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ var startContextualHelp = function () {
 	container.setAttribute('data-o-component', 'o-drawer');
 	container.setAttribute('aria-role', 'menu');
 	container.setAttribute('role', 'menu');
-	container.classList.add('o-drawer-right', 'o-drawer-animated', 'o-contextual-help-drawer');
+	container.classList.add('o-drawer-right', 'o-drawer-animated', 'o-contextual-help__drawer');
 	document.getElementsByTagName("body")[0].appendChild(container);
 
 	// init help inside of drawer

--- a/main.scss
+++ b/main.scss
@@ -9,7 +9,7 @@
 
 $drawer-borders: solid 1px #e8e8e8;
 
-.o-contextual-help-drawer {
+.o-contextual-help__drawer {
 	background: #ffffff;
 	color: #333333;
 	font-size: 16px;
@@ -18,76 +18,77 @@ $drawer-borders: solid 1px #e8e8e8;
 		color: #0381c9;
 		text-decoration: none;
 	}
-	.o-contextual-help-topics,
-	.o-contextual-help-topic-content {
-		height: 100%;
+
+	@media only screen and (max-width: 415px) {
 		width: 100%;
-		position: absolute;
-		top: 0px;
+		right: -100%;
+		z-index: 1;
+	}
+}
+
+.o-contextual-help__detail--visible {
+	.o-contextual-help__topics {
+		left: -100%;
+	}
+	.o-contextual-help__topic-content {
 		left: 0px;
-		padding-top: 48px;
-		overflow-x: hidden;
-		overflow-y: auto;
-		box-sizing: border-box;
-		transition: all 0.4s ease;
-		user-select: none;
-	}
-	.o-contextual-help-topic-content {
-		left: 100%;
-		ul {
-			padding-left: 40px;
-		}
-		.help-header {
-			display: none;
-		}
-	}
-	&.show-content {
-		.o-contextual-help-topics {
-			left: -100%;
-		}
-		.o-contextual-help-topic-content {
-			left: 0px;
-			.help-header {
-				display: block;
-			}
-		}
-	}
-	.help-header {
-		padding: 19px;
-		border-bottom: $drawer-borders;
-		a .close-x {
-			color: #333333;
-		}
-	}
-	.help-topic {
-		padding: 10px 19px;
-		border-bottom: $drawer-borders;
-		display: block;
-		&.excerpt p {
-			height: 3em;
-			overflow: hidden;
-			&:after {
-				content: '\02026';
-			}
-		}
-		h4 {
-			font-size: 18px;
-			line-height: 1.45em;
-			font-weight: normal;
-			margin-bottom: 6px;
-			margin-top: 6px;
-		}
-		p {
-			font-size: 0.9em;
-			line-height: 1.6em;
+		.o-contextual-help__header {
+			display: block;
 		}
 	}
 }
 
-@media only screen and (max-width: 415px) {
-	.o-contextual-help-drawer {
-		width: 100%;
-		right: -100%;
-		z-index: 1;
+.o-contextual-help__header {
+	padding: 19px;
+	border-bottom: $drawer-borders;
+}
+
+.o-contextual-help__topics,
+.o-contextual-help__topic-content {
+	height: 100%;
+	width: 100%;
+	position: absolute;
+	top: 0px;
+	left: 0px;
+	padding-top: 48px;
+	overflow-x: hidden;
+	overflow-y: auto;
+	box-sizing: border-box;
+	transition: all 0.4s ease;
+	user-select: none;
+}
+
+.o-contextual-help__topic {
+	padding: 10px 19px;
+	border-bottom: $drawer-borders;
+	display: block;
+	h4 {
+		font-size: 18px;
+		line-height: 1.45em;
+		font-weight: normal;
+		margin-bottom: 6px;
+		margin-top: 6px;
+	}
+	p {
+		font-size: 0.9em;
+		line-height: 1.6em;
+	}
+}
+
+.o-contextual-help__topic-content {
+	left: 100%;
+	ul {
+		padding-left: 40px;
+	}
+	.o-contextual-help__header {
+		display: none;
+	}
+}
+
+.o-contextual-help__excerpt p {
+	height: 3em;
+	overflow: hidden;
+	&:after {
+		content: '\02026';
 	}
 }

--- a/src/html/excerptT.html
+++ b/src/html/excerptT.html
@@ -1,1 +1,1 @@
-<div class="help-topic excerpt"><h4><a href="#"></a></h4><p></p></div>
+<div class="o-contextual-help__topic o-contextual-help__excerpt"><h4><a href="#"></a></h4><p></p></div>

--- a/src/html/helpT.html
+++ b/src/html/helpT.html
@@ -1,14 +1,14 @@
-<div class="o-contextual-help-topics" aria-label="help topics menu" role="navigation">
-  <div class="help-header">
+<div class="o-contextual-help__topics" aria-label="help topics menu" role="navigation">
+  <div class="o-contextual-help__header">
     Help Topics
     <a href="#o-contextual-help-drawer" data-close="o-drawer" aria-label="Close Help" style="float: right; margin-top: 2px;" class="close-help">
       <i class="oc-icon-close-x"></i>
     </a>
   </div>
-  <div class="help-topics-excerpt-list"></div>
+  <div class="o-contextual-help__excerpt-list"></div>
 </div>
-<div class="o-contextual-help-topic-content" aria-live="assertive">
-  <div class="help-header">
+<div class="o-contextual-help__topic-content" aria-live="assertive">
+  <div class="o-contextual-help__header">
     <a href="#" id="contextual-help-close-content" aria-label="Back to Help Topics">
       <i class="oc-icon-arrow-sm-left"></i> Back to Help Topics
     </a>
@@ -16,5 +16,5 @@
       <i class="oc-icon-close-x"></i>
     </a>
   </div>
-  <div id="o-contextual-help-topic-content-target" class="help-topic" role="document"></div>
+  <div id="o-contextual-help-topic-content-target" class="o-contextual-help__topic" role="document"></div>
 </div>

--- a/src/js/ContextualHelp.js
+++ b/src/js/ContextualHelp.js
@@ -89,7 +89,7 @@ function ContextualHelp(el){
 	}
 	// add event helpers for inner templates
 	el.querySelector('#contextual-help-close-content').onclick = function(){
-		me._el.classList.remove('show-content');
+		me._el.classList.remove('o-contextual-help__detail--visible');
 		return false;
 	};
 	// establish configuration
@@ -110,7 +110,7 @@ function ContextualHelp(el){
 				me.openHelpTopic(item);
 			};
 			nExcerpt.querySelector('p').innerHTML = cData.excerpt;
-			me._el.querySelector('.help-topics-excerpt-list').appendChild(nExcerpt);
+			me._el.querySelector('.o-contextual-help__excerpt-list').appendChild(nExcerpt);
 			if(list.length > 0){
 				me.populateFromList(list, cb);
 			}
@@ -120,7 +120,7 @@ function ContextualHelp(el){
 	this.init = function(){
 
 		// remove everything
-		this._el.querySelector('.help-topics-excerpt-list').innerHTML = '';
+		this._el.querySelector('.o-contextual-help__excerpt-list').innerHTML = '';
 		// populate from list
 		var theList = this.topics.slice(0);
 		this.populateFromList(theList);
@@ -141,7 +141,7 @@ function ContextualHelp(el){
 
 ContextualHelp.prototype.setLanguage = function(langCode){
 	this.lang = langCode;
-	this._el.classList.add('show-content');
+	this._el.classList.add('o-contextual-help__detail--visible');
 };
 
 ContextualHelp.prototype.openHelpTopic = function(topic){
@@ -156,7 +156,7 @@ ContextualHelp.prototype.openHelpTopic = function(topic){
 		contentTarget.querySelector('h4').innerHTML = cData.title;
 		contentTarget.querySelector('div').innerHTML = cData.content;
 	});
-	this._el.classList.add('show-content');
+	this._el.classList.add('o-contextual-help__detail--visible');
 	if(this.open){
 		this.open();
 	}


### PR DESCRIPTION
Required by the Origami spec to minimize collisions with product code. BEM removes the need to deeply nest, so this also fixes the scsslint errors.

Side note: I noticed o-drawer doesn't use the BEM underscore and dash conventions for discriminating the block, element, and modifier parts of the class name. While functionally it doesn't affect anything, it's inconsistent with the coding standards. See [o-drawer #6](https://github.com/Pearson-Higher-Ed/o-drawer/issues/6).