### PR TITLE
Fix variables

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "o-fonts": "^1.0.0",
     "o-icons": "^1.0.0",
     "o-xhr": "^1.0.0",
-    "o-collapse": "~1.0.1"
+    "o-collapse": "^1.0.1"
   },
   "main": [
     "main.scss",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function(config) {
 		// list of files / patterns to load in the browser
 		files: [
 		// Polyfill PhantomJS as it's a similar Webkit version
-		'http://polyfill.webservices.ft.com/v1/polyfill.js?ua=safari/4&features=default,WeakMap',
+		'http://polyfill.webservices.ft.com/v1/polyfill.js?ua=safari/4',
 		'test/*.test.js'
 		],
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function(config) {
 		// list of files / patterns to load in the browser
 		files: [
 		// Polyfill PhantomJS as it's a similar Webkit version
-		'http://polyfill.webservices.ft.com/v1/polyfill.js?ua=safari/4',
+		'http://polyfill.webservices.ft.com/v1/polyfill.js?ua=safari/4&features=default,WeakMap',
 		'test/*.test.js'
 		],
 

--- a/main.scss
+++ b/main.scss
@@ -10,15 +10,12 @@
 
 @include oIconsInclude(oc-icons);
 
-$drawer-borders: solid 1px #e8e8e8;
-$q-contextual-help-z-index: 995;
-
 .o-contextual-help__drawer {
 	background: #ffffff;
 	color: #333333;
 	font-size: 16px;
 	font-family: oFontsGetFontFamilyWithFallbacks(HelveticaNeue);
-	z-index: $q-contextual-help-z-index;
+	z-index: $o-contextual-help-z-index;
 	a {
 		color: #0381c9;
 		text-decoration: none;
@@ -45,7 +42,7 @@ $q-contextual-help-z-index: 995;
 
 .o-contextual-help__header {
 	padding: 19px;
-	border-bottom: $drawer-borders;
+	border-bottom: $o-contextual-help-separator-border;
 }
 
 .o-contextual-help__topics,
@@ -93,7 +90,7 @@ $q-contextual-help-z-index: 995;
 
 .o-contextual-help__topic {
 	padding: 10px 19px;
-	border-bottom: $drawer-borders;
+	border-bottom: $o-contextual-help-separator-border;
 	display: block;
 	h4 {
 		font-size: 18px;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -2,3 +2,6 @@
 /// @group o-contextual-help
 /// @link http://origami.pearsoned.com/components/o-contextual-help
 ////
+
+$o-contextual-help-z-index: 995 !default;
+$o-contextual-help-separator-border: solid 1px #e8e8e8 !default;


### PR DESCRIPTION
@dstack. Note that there are two changes here, one of which is to add `WeakMap` to the polyfills for running the unit tests with Karma/PhantomJS. This is because `o-collapse` requires the consumer to provide the polyfill, and thus the tests fail because WeakMap is undefined (and the [current version build](https://travis-ci.org/Pearson-Higher-Ed/o-contextual-help/builds/82802511) is broken). For the short term, we can update `o-collapse` to use `o-weakmap` and get away with a minor version bump. It won't be a concern with the ES6/obt v4 conversion.